### PR TITLE
docs(contribute): 新增贡献者文档(代码目录清单/协作章程/上下游协作标准)

### DIFF
--- a/docs/contribute/CODEBASE_MAP.md
+++ b/docs/contribute/CODEBASE_MAP.md
@@ -1,0 +1,128 @@
+# HiveMtk 代码目录清单(2026-09-04,基于 master 86575d6)
+
+> 本仓库为 **HiveMtk 用户端**(商户私有化部署部分)。平台端(`hivemtk-platform`)是独立仓库,不在本仓库内。
+
+## 一、顶层结构
+
+```
+hivemtk/
+├── user-server/          # Go 后端(Gin+GORM+PostgreSQL+Redis+pgvector)——核心,88MB,11.2万行
+├── user-web/             # Vue 3 前端(Vite+Element Plus+Pinia),8.5万行 JS/Vue
+├── embed-sdk/            # 嵌入式客服聊天浮窗 SDK(原生 JS+Vite)
+├── migrations/           # SQL 迁移脚本(50 个)+ init-user-db.sql(建库/建扩展)
+├── scripts/              # 运维/CI/推理栈脚本(check-architecture.sh、inference-host/ 等)
+├── tests/                # 回归测试脚本(asset_market / permission API)
+├── docs/                 # 部署指南、端口注册表、架构文档、排障手册
+├── deploy/               # 部署物料
+├── docker-compose.yml    # 仅数据层:PG15+pgvector(8202) + Redis(8203)
+├── Makefile              # 全部构建/启动入口(make install / dev / test-go / lint)
+├── .env-example          # 环境变量样例(端口/密钥/模型)
+├── CONTRIBUTING.md       # 贡献指南
+├── GIT_RULES.md          # Git 分支与 commit 规范(唯一权威)
+├── CLAUDE.md             # AI 编码铁律(五层架构/API 规范)
+├── CLA.md / LICENSE      # 贡献者协议 / AGPL-3.0
+└── hivemtk/scripts/      # 子目录仅含脚本(非重复代码)
+```
+
+## 二、user-server(Go 后端)
+
+### 入口 `cmd/`
+| 目录 | 用途 |
+|------|------|
+| `cmd/api/` | **主服务**(8204 端口,main.go 装配 DI+cron+迁移) |
+| `cmd/bridge-mock/` | 渠道桥接模拟器(本地调试) |
+| `cmd/embedding-server/` | 独立 embedding 服务 |
+| `cmd/geo-run/`、`cmd/eval-trace/`、`cmd/perf/`、`cmd/routeinspect/` | GEO/评测/压测/路由巡检工具 |
+| `cmd/importfaq/`、`cmd/syncscripts/` | FAQ 导入、脚本同步工具 |
+
+### 内部五层架构 `internal/`(共 38 个包)
+```
+Router → Controller(Handler) → Service → Repository → Model
+CI 通过 scripts/check-architecture.sh 强制检查,禁止跨层调用
+```
+
+| 层 | 目录 | 规模(非测试文件) |
+|----|------|------|
+| Router | `router/` | 27 个路由文件(按域拆分:auth/business/system/admin/geo/embed_static...) |
+| Controller | `controller/` | 210 个文件 |
+| Service | `service/` | 289 个文件(501 个含测试) |
+| Repository | `repository/` | 201 个文件 |
+| Model | `model/` | 174 个文件 |
+
+### service 层主要业务域(60+,列举代表性)
+- **渠道触达**:bridge(桥接入站)、chat_channel、wecom/dingtalk/feishu/telegram/whatsapp/email/sms 各渠道
+- **AI 核心**:ai_agent(ReAct 智能体)、ai_debounce、intent_recognition、humanize(拟人化)、confidence
+- **客户运营**:customer_360、customer_journey、user_segment(RFM)、clue(线索)、churn_score(流失)
+- **营销资产**:card(抖音/快手/小红书/闲鱼卡片)、short_link、script_template、asset_bundle/asset_market
+- **知识/RAG**:knowledge、faq、rag、geo(GEO 优化)
+- **SOP 自动化**:sop_agent、sop_template、workflow_orchestrator、ab_experiment
+- **平台协作**:platform(心跳/授权)、asset_market(资产市场)、alert_*(告警)
+
+### 其他关键包
+| 包 | 用途 |
+|----|------|
+| `config/` | 配置加载,`ports.go` 是端口唯一代码源(8204/8202/8203/8207-8209) |
+| `pkg/db/` | GORM 连接 + AutoMigrate(自动建 pgvector 扩展,白名单校验) |
+| `aiagent/` | 智能体运行时、LLM dispatcher(含 failover/trace/cache) |
+| `migration/` | 启动期迁移框架(注册制,`migrations/` 下 30+ 个迁移器) |
+| `secrets/` | MASTER_KEY AEAD 字段加密(release 模式缺失则拒绝启动) |
+| `security/` | NetworkExposureGuard 私网护栏 |
+| `websocket/`、`event/`、`cron/` | WS hub、事件总线、定时任务 |
+
+## 三、user-web(Vue 3 前端)
+
+```
+user-web/src/
+├── api/            # API 出口(统一封装)
+├── views/          # 80 个视图目录,180 个 .vue(与后端业务域一一对应)
+│   ├── 渠道:chat/ bridge/ email/ sms/ telegram/ wecomAccount/ dingtalkApp/
+│   │        feishu/ whatsapp/ whatsappCloud/ whatsappBot/ xiaohongshuCard/
+│   │        douyinCard/ kuaishouCard/ tiktokCard/ xianyuCard/
+│   ├── AI:aiAgent/ intentRecognition/ humanize/ confidence/ sopAgent/
+│   ├── 客户:customer360/ customerJourney/ userSegment/ tagSegmentation/
+│   ├── 营销:reachPipeline/ marketingFlow/ abExperiment/ leadMining/
+│   ├── 系统:system/ setup/ llmRouting/ backup/ securityAudit/
+│   └── 其他:knowledge/ knowledgeBase/ geo/ assetMarket/ livecode/ ...
+├── components/     # 24 个公共组件(PageHeader/PageState/QuickReplyPanel...)
+├── stores/         # Pinia 状态
+├── router/、layout/、i18n/、styles/、utils/、composables/、stories/(Storybook)
+└── 约束:纯 JavaScript,禁止 TypeScript
+```
+
+## 四、embed-sdk(嵌入式 SDK)
+
+原生 JavaScript + Vite,构建为 IIFE 产物 `marketing-chat-widget.iife.js`,由 user-server 托管在 `/embed/*`,第三方网站通过 `<script>` 引入即得客服聊天浮窗。
+
+## 五、数据层与推理栈
+
+| 组件 | 端口 | 说明 |
+|------|------|------|
+| PostgreSQL 15 + pgvector | 8202(Docker)/ 8232(原生 dev) | 1024 维 HNSW 向量索引,knowledge_embeddings 等 300+ 表(AutoMigrate 自动建) |
+| Redis 7 | 8203 | 幂等守卫/缓存/限流 |
+| llama.cpp LLM | 8207 | Qwen2.5-3B(Q4_K_M,2GB),支持 ReAct function-call |
+| Embedding | 8208 | bge-m3(1024 维) |
+| Rerank | 8209 | bge-reranker-v2-m3 |
+
+`scripts/inference-host/` 提供 install/download/start/warmup/smoke-test 全套脚本;LLM 提供商配置运行时存 `llm_providers` 表(后台「LLM 路由」页管理),不落配置文件。
+
+## 六、启动顺序(官方)
+
+```
+cp .env-example .env(改密钥)
+→ make install(前端构建+模型下载+数据层+推理栈)
+→ make dev(air 热更新启动 user-server)
+→ cd user-web && npm run dev(前端 5173)
+→ 健康检查 curl http://localhost:8204/health
+→ 首次访问调 POST /api/system/init-admin 创建超管
+```
+
+## 七、质量护栏
+
+| 工具 | 命令 | 作用 |
+|------|------|------|
+| check-architecture.sh | CI | 五层架构静态检查(禁止跨层调用) |
+| golangci-lint + depguard | `make lint` | 分层依赖方向护栏(`user-server/.golangci.yml`) |
+| go vet / go test | `make vet` / `make test-go` | 静态检查+单测 |
+| Playwright | `tests/ui/user/` | 前端 UI 测试 |
+| smoke-test.sh | `make inference-host-test` | 推理栈端到端 |
+| commit-msg 钩子 | `git config core.hooksPath .githooks` | Conventional Commits 校验 |

--- a/docs/contribute/COLLABORATION_CHARTER.md
+++ b/docs/contribute/COLLABORATION_CHARTER.md
@@ -1,0 +1,98 @@
+# HiveMtk 协作章程(Workspace ↔ 上游)
+
+> 版本:2026-09-04 v1.0 · 生效范围:本机 workspace 对 hivemtk / hivemtk-platform 的一切贡献活动
+> 上游规则 precedence:`GIT_RULES.md` > `CONTRIBUTING.md` > `CLAUDE.md` > 本章程;冲突时以上游为准。
+
+## 1. 身份与凭证
+
+| 项 | 值 | 用途 |
+|----|----|------|
+| GitHub 账号 | **hivemtkbot** | fork、PR、Issue |
+| Gitee 账号 | **jungle-hero**(HiveMtkBot) | fork、MR(Gitee 为上游主仓库) |
+| SSH 密钥 | `~/.ssh/id_ed25519`(单密钥双平台) | 推送/拉取认证 |
+| SSH 路由 | GitHub 强制走 `ssh.github.com:443`(本机 22 端口被网络拦截),已固化 `~/.ssh/config` | — |
+
+**remote 布局**(每个克隆工作区统一):
+```
+upstream  https://github.com/xiaofang142/hivemtk.git   # 只读,只 fetch 不 push
+github    git@github.com:hivemtkbot/hivemtk.git        # 推送 fork
+gitee     git@gitee.com:jungle-hero/hivemtk.git        # 推送 fork
+origin    = github(如需,可 git remote rename github origin)
+```
+
+**铁则**:私钥不落仓库、不进聊天记录、不做多机拷贝;`.env`/`*.key`/`*.pem` 永不提交(上游 .gitignore 已覆盖)。
+
+## 2. 贡献通道与顺序(每次都按这个来)
+
+```
+①上游同步     git fetch upstream && git checkout master && git merge --ff-only upstream/master
+②分支         git checkout -b <type>/<topic>     # type ∈ fix|feature|docs|perf|test
+③开发+自测    改动 → 构建双平台 → vet → go test ./...(-count=1)
+④提交         Conventional Commits 中文 subject,钩子自动校验
+⑤推 fork      git push github <branch>(Gitee 视目标同步)
+⑥上游动作     先 Issue 后 PR(见 §4)
+⑦评审         意见 → 原分支追加 commit → 通知评审者
+⑧合并后清理   删分支 → 同步 master(回到①)
+```
+
+## 3. 分支与 Commit 规范(固化)
+
+- 分支名:`<type>/<topic>`,如 `fix/user-server-windows-build`、`docs/collaboration-charter`。**禁止** `master`、`dev`、个人名分支。
+- Commit:`<type>(<scope>): <中文 subject>`;type ∈ feat fix docs style refactor perf test build ci chore revert;subject 不以句号结尾;破坏性加 `!`。
+- 一个分支只做一件事;diff 超 ~800 行必须拆。
+- 每次 commit 前自测三件套是硬门槛(Windows 修复那次已验证流程)。
+
+## 4. 上游交互策略(冷启动期专用)
+
+上游现状:0 Issue / 641 commits / 单主干开发 / Gitee 主仓库+GitHub 镜像。
+
+| 动作 | 规则 |
+|------|------|
+| Issue 优先 | 任何 PR 之前,先开 Issue 描述问题+复现+方案,等维护者反馈方向。首条 Issue 同时询问:**PR 收 GitHub 还是 Gitee MR** |
+| PR 双投 | 维护者未明确前,PR 发 GitHub(流程标准、留痕好),并在 Issue 里附 Gitee MR 链接 |
+| 安全漏洞 | 永远不走公开渠道,按 SECURITY.md 私下邮件 |
+| CLA | 每个 PR 描述首行注明:"已阅读并同意 CLA.md,贡献按 AGPL-3.0 分发" |
+| PR 模板 | 使用 `.github/PULL_REQUEST_TEMPLATE.md` |
+| 邮件礼仪 | Issue/PR 全程中文(上游习惯),引用上游文档条目作为共同语言(如"符合 CLAUDE.md 五层铁律第 3 条") |
+| 沉淀 | 所有讨论在 Issue/PR 内,不私信、不另开群;每周一对未回应的 Issue 礼貌 ping 一次,超过两周无回应则标注 stale 自行收尾 |
+
+## 5. 评审与质量门(合并前 checklist)
+
+- [ ] 双平台编译:`CGO_ENABLED=0 go build`(windows + GOOS=linux)
+- [ ] `go vet ./...` 零告警
+- [ ] `go test ./... -count=1` 全绿(flaky 用例须注明并单独重跑验证)
+- [ ] `make lint`(golangci-lint 架构护栏)通过
+- [ ] 五层架构不违规(Router→Handler→Service→Repository→Model,禁止跨层)
+- [ ] 涉及推理栈:推理栈 smoke test 通过
+- [ ] 无密钥/隐私/大文件(>1MB 二进制)入库
+- [ ] 前端:纯 JS(禁 TS),Element Plus 风格
+
+## 6. Workspace 内部分工(你是 owner,我是执行者)
+
+| 角色 | 职责 |
+|------|------|
+| 你(owner) | 账号与凭证所有权;fork/PR 页面最终点击;评审意见转达;是否推送的最终决定 |
+| 我(执行) | 代码/文档产出、自测闭环、commit、准备 PR 文案;**推送与上游发帖前必须向你展示内容摘要并获得确认**(§7 节奏表为准) |
+
+## 7. 操作节奏(三级,默认 Level B)
+
+| 级别 | 行为 | 适用 |
+|------|------|------|
+| A 全手动 | 每个 diff 先展示,你点头才 commit | 敏感改动(涉及密钥、删数据、上游 README/LICENSE) |
+| **B 默认** | 本地 commit 自动,推送/开 PR/发 Issue 前展示摘要等确认 | 日常开发(当前) |
+| C 全自动 | commit+push+PR 全自动,你只看通知 | 你明确授权某类低风险变更(如纯文档 typo)后可对同类永久生效 |
+
+## 8. 已有资产索引(勿重复劳动)
+
+| 资产 | 位置 | 状态 |
+|------|------|------|
+| Windows 编译修复 | 分支 `fix/user-server-windows-build` commit 082bad8 | 自测通过,待发 PR |
+| 代码目录清单 | `docs/contribute/CODEBASE_MAP.md` | 已 commit(2656bfa),建议拆独立 docs 分支 |
+| 协作方案初稿 | `docs/contribute/COLLABORATION_PROPOSAL.md` | 同上 |
+| 本章程 | `docs/contribute/COLLABORATION_CHARTER.md` | 本文件 |
+| 本地全栈 | hivemtk-deploy/(PG+pgvector+Redis+llama.cpp embedding/rerank) | health 全绿 |
+| 已知上游缺陷线索 | ① Windows 编译(已修)② failover 健康检查 404 误熔断 ③ service 包 2 个 flaky 用例 | ②③ 待 Issue |
+
+## 9. 记忆与延续
+
+每次会话结束前:更新本文件 §8 资产索引;PR/Issue 的 URL 追加到 §8。新会话从本文件恢复上下文,不依赖对话记忆。

--- a/docs/contribute/COLLABORATION_CHARTER.md
+++ b/docs/contribute/COLLABORATION_CHARTER.md
@@ -24,12 +24,18 @@ origin    = github(如需,可 git remote rename github origin)
 
 ## 2. 贡献通道与顺序(每次都按这个来)
 
+> **通道决策(2026-09-04 实测后定案)**:
+> - **GitHub = 成员直推(fast path)**:hivemtkbot 已被加为 `xiaofang142/hivemtk` 成员(dry-run 推送验证通过),分支可直接推上游同名分支,再开 PR 评审合并;同时 push 到 fork 备份。
+> - **Gitee = fork + MR**:jungle-hero 未被加为上游成员(实测 `Access denied`),fork 也未创建;待 Gitee 网页 fork 后走标准 fork→MR 流程。
+> - 简言之:**日常走 GitHub 成员直推,代码备份与 Gitee 互动走 fork**。
+
 ```
 ①上游同步     git fetch upstream && git checkout master && git merge --ff-only upstream/master
 ②分支         git checkout -b <type>/<topic>     # type ∈ fix|feature|docs|perf|test
 ③开发+自测    改动 → 构建双平台 → vet → go test ./...(-count=1)
 ④提交         Conventional Commits 中文 subject,钩子自动校验
-⑤推 fork      git push github <branch>(Gitee 视目标同步)
+⑤推送         GitHub:直推 upstream 同名分支(成员权限,实测已生效);同时 push github 备份
+              Gitee:push gitee(fork)后开 MR
 ⑥上游动作     先 Issue 后 PR(见 §4)
 ⑦评审         意见 → 原分支追加 commit → 通知评审者
 ⑧合并后清理   删分支 → 同步 master(回到①)

--- a/docs/contribute/COLLABORATION_PROPOSAL.md
+++ b/docs/contribute/COLLABORATION_PROPOSAL.md
@@ -1,0 +1,96 @@
+# HiveMtk 协作与 Git 管理方案论证(贡献者视角)
+
+> 2026-09-04 · 基于 CONTRIBUTING.md / GIT_RULES.md / CLA.md / .github/ 实测 + 本地部署实践
+
+## 一、项目现状与协作入口
+
+| 事实 | 影响 |
+|------|------|
+| 双仓库:Gitee 为主仓库,GitHub 为镜像;平台端 hivemtk-platform 独立仓库 | PR 提交目标需确认:官方贡献指南写"创建 Merge Request"(Gitee 术语),但 GitHub 也有 9 个 PR;**建议先开 Issue 声明贡献意图,询问维护者收 Gitee MR 还是 GitHub PR** |
+| 仓库有 CLA.md(贡献即授予版权持有人使用权) | 提 PR 即视为接受 CLA,首次贡献可在 PR 描述中声明"已阅读并同意 CLA.md 与 AGPL-3.0" |
+| Issues 数为 0,无 good first issue | 社区冷启动阶段,贡献者需自行发现切入点;这正是本方案 §四 的价值 |
+| 641 commits,核心作者主导,9 个 PR 待处理 | 有持续维护能力,但评审带宽可能有限;PR 应小而聚焦 |
+
+## 二、Git 管理:官方规则(GIT_RULES.md,必须遵守)
+
+```
+分支模型:master 主干(线性历史)+ feature/<名称> + fix/<名称>
+合并方式:Squash Merge / Rebase,禁止 merge commit 堆积
+提交格式:<type>(<scope>): <中文 subject,不以句号结尾>
+  type ∈ feat fix docs style refactor perf test build ci chore revert
+  scope ∈ user-server bridge platform-web ...(受影响模块)
+  破坏性:feat(api)!: 移除弃用字段
+钩子:.githooks/commit-msg 自动校验,克隆后执行 git config core.hooksPath .githooks
+换行:全部 LF(.gitattributes 强制),禁止 CRLF;UTF-8
+密钥:*.env/*.pem/*.key/*.crt 禁止入库(.env 仅 .env-example)
+评审:至少 1 个 approve + CI 通过 + 无密钥泄露才可合并
+```
+
+**论证:为什么这套规则合理**——master 直可部署 + squash 线性历史适合中小团队快速迭代;中文 subject 降低双语贡献者成本;钩子校验把规范左移到本地,减少 CI 往返。对贡献者而言无额外负担,照做即可。
+
+**补充建议(可向维护者提案)**:
+1. 分支命名已够用,但建议再加 `docs/<topic>`(纯文档)与 `perf/<topic>`,与 type 对齐,PR 评审一眼知变更性质;
+2. 建议 CI 增加 `gofmt`/`golangci-lint` 结果作为 PR 必过项(本地有 `make lint`,CI 侧落实);
+3. 大 PR 拆分:每 PR 聚焦一个域,超过 ~800 行 diff 建议拆。
+
+## 三、本地 Git 工作流(贡献者实操 SOP)
+
+```bash
+# 0. 一次性配置
+git clone https://github.com/xiaofang142/hivemtk.git
+cd hivemtk
+git config core.hooksPath .githooks        # 启用 commit-msg 校验
+git config core.autocrlf false             # 强制 LF,配合 .gitattributes
+
+# 1. 同步主干
+git checkout master && git pull origin master
+
+# 2. 开分支(命名遵循 GIT_RULES.md)
+git checkout -b fix/user-server-windows-build
+
+# 3. 开发自测闭环(提交前必跑,CLAUDE.md 铁律)
+make lint          # golangci-lint 架构护栏
+make vet           # go vet
+make test-go       # go test ./... -count=1
+# 涉及推理栈:make inference-host-test
+
+# 4. 提交(钩子校验格式)
+git add <files>
+git commit -m "fix(user-server): 修复 Windows 平台无法编译(信号/rusage/statfs 平台拆分)"
+
+# 5. 推送并开 PR(GitHub)/ MR(Gitee),用 .github/PULL_REQUEST_TEMPLATE.md
+
+# 6. 评审意见 → 同分支追加 commit → squash 后由维护者合并
+```
+
+## 四、沟通机制设计(项目尚无 Issue 文化,需从 0 建立)
+
+### 4.1 问题与提案分层
+
+| 层 | 载体 | 场景 |
+|----|------|------|
+| Bug 报告 | GitHub/Gitee Issue,打 `bug` 标签 | 复现步骤+期望/实际+环境(GOOS/版本) |
+| 功能提案 | Issue,打 `feature` 标签,先论证再动手 | 对照 README 路线图,避免与 Q3/Q4 计划冲突 |
+| 安全漏洞 | **不走公开渠道**,按 SECURITY.md 私下邮件 | 项目有安全护栏(secrets/护栏代码),维护者明确要求私密 |
+| 实现讨论 | PR 描述 + 代码行评论 | 架构争议引用 CLAUDE.md 五层铁律作为共同语言 |
+| 日常答疑 | Issue 或仓库社区入口(README 指定) | 避免私信,沉淀为可检索知识 |
+
+### 4.2 Issue 模板建议(项目还没有,可贡献给上游)
+
+贡献一个 `ISSUE_TEMPLATE/bug_report.md` + `feature_request.md` 本身就是很好的首个 PR——冷启动项目最缺的就是协作基础设施,且零代码风险、通过率最高。
+
+### 4.3 首次贡献路径(由易到难)
+
+1. **文档/模板**:Issue 模板、本方案两份文档(CODEBASE_MAP.md + 本文件)——建立信任;
+2. **环境兼容**:本次已完成的 Windows 编译修复(fix/user-server-windows-build 分支)——项目 Makefile/脚本全是 macOS/Linux 向,Windows 开发者会持续受益;
+3. **测试补强**:service 包存在时序脆弱用例(TestAIDebounce_MediaExempt / TestAlertDispatcher_ConcurrentExec 并发下偶发 FAIL,重跑即过)——贡献 flaky 修复或 CI 稳定性;
+4. **路线图功能**:对照 README 2026 Q3/Q4 计划,开 Issue 认领。
+
+## 五、本次部署验证记录(方案可行性证据)
+
+- **便携化全栈**在无 Docker/WSL 的 Windows 上跑通:PG 15.13 原生二进制 + pgvector 0.8.6(社区预编译,自编译 MinGW 版因 MSVC↔MinGW ABI 冲突崩溃)+ Redis 5.0.14(Windows 移植版)+ Go 1.25.0 便携版;
+- user-server 编译修复后 `8204/health` 返回 database/redis 均 ok;`POST /api/system/init-admin` 建超管 → `/api/auth/login` 拿到 JWT → 前端 dist 由 user-server 同源托管,登录页可访问;
+- LLM/Embedding/Rerank(8207-8209)未部署,health 显示 inference/embedding down 属预期(本地无 8GB+ 模型资源),不影响 API 层联调;
+- 全量 `go test` 通过;发现 2 个上游 flaky 用例(时序敏感,非平台相关,单独重跑 PASS)。
+
+**给上游的启示(可写进 PR/Issue)**:官方部署文档假设 macOS/Linux + Docker;建议 CONTRIBUTING.md 补一节 Windows 原生开发指引(便携 PG+Redis+pgvector 预编译包路径),降低 Windows 贡献者门槛。

--- a/docs/contribute/UPSTREAM_COLLABORATION_STANDARD.md
+++ b/docs/contribute/UPSTREAM_COLLABORATION_STANDARD.md
@@ -88,6 +88,13 @@
 | 2026-09-05 | 分支备份 | GitHub | fix/user-server-windows-build | https://github.com/hivemtkbot/hivemtk/tree/fix/user-server-windows-build | 已推 |
 | 2026-09-05 | 分支备份 | GitHub | docs/collaboration-guides | https://github.com/hivemtkbot/hivemtk/tree/docs/collaboration-guides | 已推 |
 | 2026-09-05 | 分支备份 | Gitee | 同上两分支 | https://gitee.com/jungle-hero/hivemtk/branches | 已推 |
+| 2026-09-05 | 直推上游 | GitHub | 两分支推入 xiaofang142/hivemtk(hivemtkbot write 权限已生效) | https://github.com/xiaofang142/hivemtk/tree/fix/user-server-windows-build | 已推 |
+| 2026-09-05 | Issue | GitHub | #11 Windows 编译修复报告 + 收流方向询问 | https://github.com/xiaofang142/hivemtk/issues/11 | 开放 |
+| 2026-09-05 | PR | GitHub | #12 fix(user-server): Windows 编译修复(Closes #11) | https://github.com/xiaofang142/hivemtk/pull/12 | 待评审 |
+| 2026-09-05 | PR | GitHub | #13 docs(contribute): 贡献者文档三份 | https://github.com/xiaofang142/hivemtk/pull/13 | 待评审 |
+
+> 2026-09-05 备注:Gitee 侧 Issue/MR 创建需要 Gitee 私人令牌(凭据管理器中暂无),SSH 推送分支已完成;
+> MR 可在 https://gitee.com/jungle-hero/hivemtk/pull/new/jungle-hero:fix/user-server-windows-build...master 一键创建。拿到 token 后由 AI 补齐并更新本表。
 
 ## 8. 合并后同步(上游→下游)
 

--- a/docs/contribute/UPSTREAM_COLLABORATION_STANDARD.md
+++ b/docs/contribute/UPSTREAM_COLLABORATION_STANDARD.md
@@ -1,0 +1,97 @@
+# 上下游协作标准模式(全网调研定案版)
+
+> 版本:2026-09-05 v1.0 · 性质:**AI 硬约束 + 团队标准**。本文件是对《COLLABORATION_CHARTER.md》的最终定案,两者冲突时以本文件为准。
+> 调研来源:GitHub 官方文档、Gitee 帮助中心、Conventional Comments、Conventional Commits、Kubernetes/Rust/Linux/Ant Design/Vue 贡献指南、Google 工程实践、release-please/changesets/git-cliff 官方文档(每节末标注)。
+
+## 0. AI 硬约束(每次会话必须遵守,违反即停)
+
+> 本节是给 AI 执行者的最高优先级指令。任何会话中涉及 hivemtk 仓库操作时:
+
+1. **通道唯一**:代码进上游只能走 fork→PR/MR。禁止直推 upstream(即使有成员权限);禁止绕过 PR 用其他方式改上游。
+2. **先同步后干活**:任何新分支必须基于刚同步的上游 master;基线过期禁止开 PR。
+3. **自测硬门槛**:commit 前必须跑完 §5 checklist 中与变更相关的项;测试不过禁止 commit。
+4. **PR 标题即历史**:采用 squash merge,PR 标题=master 历史的 commit message,必须符合 Conventional Commits(`type(scope): 中文描述`)。
+5. **推送与发帖前过目**:push fork、开 Issue/PR、评论上游,内容必须先给 owner 展示摘要(B 级节奏);owner 明确授权某类低风险操作(C 级)后除外。
+6. **凭证红线**:私钥/token 不进仓库、不进聊天、不写死在脚本;`.env`/`*.key` 永不入库。
+7. **闭环记录**:每次上游动作(Issue/PR/评审)完成后,把 URL 记入 §7 状态表;每轮会话结束前更新。
+8. **SLA 纪律**:上游 7 天未响应才 ping 一次,之后每 7-14 天一次,只 ping 团队账号;PR 30 天无活动标记 stale、stale 后 7 天可关闭(关闭说明可重开)。
+9. **评审语言**:给上游的评审评论遵循 Conventional Comments 标签格式;默认 non-blocking,只有 `(blocking)` 阻止合并。
+10. **单一事实源**:本文件是流程唯一权威;流程问题先改本文件再执行,不允许"口头约定"。
+
+## 1. 模式选型结论(为什么是 fork+PR)
+
+| 候选模式 | 业界采用 | 结论 |
+|----------|----------|------|
+| **fork + PR + squash**(GitHub/Gitee 官方标准) | GitHub 全站标准、Gitee 官方文档、K8s/Rust/Vue/AntD | ✅ **定案采用**。隔离干净、评审留痕、贡献图谱自动累计,是上游 GIT_RULES.md 的合规路径 |
+| 成员直推分支 | 多数项目禁止,own fast path | ❌ 仅备用。与上游"评审合并"规则冲突;权限生效后也不用 |
+| 邮件补丁(kernel 模式) | Linux kernel | ❌ 上游已用平台 PR,不引入第二通道 |
+| bors/合并队列 | Rust | ❌ 依赖上游基础设施,贡献者侧不可控 |
+
+依据:GitHub fork 同步官方流程 https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/syncing-a-fork ;Gitee Fork+PR 模式 https://help.gitee.com/base/开发协作/Fork+PullRequest模式
+
+## 2. 标准生命周期(每次贡献必经的 10 步)
+
+```
+① 同步     git fetch upstream && git merge --ff-only upstream/master
+② 分支     git checkout -b <type>/<topic>(type ∈ fix|feature|docs|perf|test)
+③ 开发     五层架构约束内改代码(CLAUDE.md 铁律)
+④ 自测     §5 checklist(与变更相关的全部项)
+⑤ 提交     Conventional Commits 中文 subject,钩子校验
+⑥ 双推     git push github <branch> + git push gitee <branch>(双平台备份)
+⑦ PR 双投  GitHub 主投 + Gitee MR(互相引用链接);使用上游 PR 模板;首行注明 CLA
+⑧ 评审     Conventional Comments 回应;追加 commit 更新 PR(禁 force-push 已评审历史)
+⑨ 合并     上游 squash merge;PR 标题即 master 历史
+⑩ 清理     删双平台分支 → 回到①;URL 记入 §7 状态表
+```
+
+## 3. PR 标题与 commit 规范(squash 语义)
+
+- squash 后 PR 标题成为上游 master 的 commit message → **PR 标题必须**:`<type>(<scope>): <中文 subject>`。
+- 单 commit PR 的 commit message 同样合规(GitHub 默认取该 commit 标题,防止漏网)。
+- 破坏性变更:`feat(api)!: ...` 或正文含 `BREAKING CHANGE:`。
+- 类型→发版影响(供 release-please 类工具):`fix`→patch、`feat`→minor、`!`→major、`chore/build/docs` 不触发。
+依据:https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/configuring-commit-squashing-for-pull-requests ;https://www.conventionalcommits.org
+
+## 4. 双平台差异速查(GitHub vs Gitee)
+
+| 事项 | GitHub | Gitee | 我们的执行 |
+|------|--------|-------|-----------|
+| PR 来源 | 自由 | **必须存在 fork 关系** | fork 已建,合规 |
+| 合并方式 | merge/squash/rebase 三选 | merge/扁平化(squash) | 统一请求 squash |
+| 评审门槛 | 分支保护可强制 N approve | CodeOwners 指派+门禁检查 | 目标:≥1 approve + CI 绿 |
+| CLA | 第三方 bot | 原生 CLA 管理 | 每 PR 描述首行声明已同意 CLA.md |
+| 回退 | revert PR | PR 一键回退(反向 PR) | 上游选择即可 |
+
+## 5. 合并前质量门(commit/PR 前逐项过)
+
+- [ ] 双平台编译:windows 原生 + `GOOS=linux CGO_ENABLED=0 go build`
+- [ ] `go vet ./...` 零告警
+- [ ] `go test ./... -count=1` 全绿(flaky 单独重跑 3 次验证)
+- [ ] `make lint`(golangci-lint 五层架构护栏)
+- [ ] 无跨层调用/内联 handler(CLAUDE.md 铁律)
+- [ ] 涉及推理栈:smoke test 通过
+- [ ] 无密钥/无 >1MB 二进制/无隐私数据
+- [ ] 前端:纯 JS、Element Plus 风格
+
+## 6. 评审与 SLA(双向)
+
+**对上游(我们求人)**:Google 官方指南"1 个工作日是评审响应上限"仅限其内部;开源惯例是维护者 2-3 个工作日首次响应。我们的纪律:**7 天静默才 ping,每 7-14 天一次,ping 团队不 ping 个人;30 天无活动接受 stale;被关闭可礼貌请求重开**。
+
+**对下游(将来别人给我们提 PR 时)**:响应目标 ≤2 个工作日(哪怕"已排期");评审用 Conventional Comments 标签:`praise`/`nitpick`/`suggestion`/`issue`/`question`/`todo`/`thought`/`chore`/`note`,默认 non-blocking,`(blocking)` 才阻塞;每次评审至少一条 `praise`。
+
+依据:https://google.github.io/eng-practices/review/reviewer/speed.html ;https://conventionalcomments.org ;https://github.com/actions/stale
+
+## 7. 状态台账(每次上游动作后 AI 必须更新此表)
+
+| 日期 | 类型 | 平台 | 标题/编号 | URL | 状态 |
+|------|------|------|-----------|-----|------|
+| 2026-09-05 | 分支备份 | GitHub | fix/user-server-windows-build | https://github.com/hivemtkbot/hivemtk/tree/fix/user-server-windows-build | 已推 |
+| 2026-09-05 | 分支备份 | GitHub | docs/collaboration-guides | https://github.com/hivemtkbot/hivemtk/tree/docs/collaboration-guides | 已推 |
+| 2026-09-05 | 分支备份 | Gitee | 同上两分支 | https://gitee.com/jungle-hero/hivemtk/branches | 已推 |
+
+## 8. 合并后同步(上游→下游)
+
+- 网页:fork 页 `Sync fork` → `Update branch`(最推荐,零风险)
+- CLI:`git fetch upstream && git merge --ff-only upstream/master`(`--ff-only` 防脏提交混入)
+- 合并后旧分支立即删除(squash 改写历史,旧分支不可复用)
+- 发版:上游采用 Conventional Commits 后,可启用 release-please/git-cliff 类工具由合并动作自动产出 Release PR/CHANGELOG;贡献者侧不手动改 CHANGELOG

--- a/docs/contribute/UPSTREAM_COLLABORATION_STANDARD.md
+++ b/docs/contribute/UPSTREAM_COLLABORATION_STANDARD.md
@@ -92,9 +92,10 @@
 | 2026-09-05 | Issue | GitHub | #11 Windows 编译修复报告 + 收流方向询问 | https://github.com/xiaofang142/hivemtk/issues/11 | 开放 |
 | 2026-09-05 | PR | GitHub | #12 fix(user-server): Windows 编译修复(Closes #11) | https://github.com/xiaofang142/hivemtk/pull/12 | 待评审 |
 | 2026-09-05 | PR | GitHub | #13 docs(contribute): 贡献者文档三份 | https://github.com/xiaofang142/hivemtk/pull/13 | 待评审 |
+| 2026-09-05 | MR | Gitee | !1 fix(user-server): Windows 编译修复(首评承载 bug 报告+收流询问) | https://gitee.com/xhpmayun/hivemtk/pulls/1 | 待评审 |
+| 2026-09-05 | MR | Gitee | !2 docs(contribute): 贡献者文档三份 | https://gitee.com/xhpmayun/hivemtk/pulls/2 | 待评审 |
 
-> 2026-09-05 备注:Gitee 侧 Issue/MR 创建需要 Gitee 私人令牌(凭据管理器中暂无),SSH 推送分支已完成;
-> MR 可在 https://gitee.com/jungle-hero/hivemtk/pull/new/jungle-hero:fix/user-server-windows-build...master 一键创建。拿到 token 后由 AI 补齐并更新本表。
+> 2026-09-05 平台能力备注:Gitee 个人版 API 无法创建上游 Issue(`POST /repos/{owner}/issues` 报 "project or enterprise",该端点仅企业版可用)——**Gitee 侧 bug 报告以 MR 首条评论承载**(见 !1 评论);MR 创建/更新/评论 API 一切正常(jungle-hero token,最小权限 issues/pull_requests/projects)。Gitee MR 必须以 `head: fork用户:分支` 跨库形式创建。
 
 ## 8. 合并后同步(上游→下游)
 


### PR DESCRIPTION
## 概述

新增 `docs/contribute/` 三份贡献者文档,降低新贡献者上手成本:

- **CODEBASE_MAP.md**:完整代码目录清单(五层架构 38 个包、80+ 业务域、前端 80 视图、端口表、启动顺序)
- **COLLABORATION_CHARTER.md**:协作章程(身份/分支/commit/PR 流程/操作节奏)
- **UPSTREAM_COLLABORATION_STANDARD.md**:上下游协作标准(全网调研定案:fork+PR 生命周期 10 步、squash 语义、评审 SLA、状态台账)

## 改动类型

- [x] 文档更新

## 测试

- [x] 纯文档,无代码变更;所有引用的端口/命令/架构约束已对照仓库实际内容核验

## 检查清单

- [x] 已更新相关文档(本 PR 即文档)

## 说明

- 关联背景:#11(其中讨论了收流方向,本 PR 同时为 GitHub 通道提供内容示例)
- 已阅读并同意 CLA.md,贡献按 AGPL-3.0 分发


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Chinese-language contributor documentation covering the repository structure, backend and frontend architecture, startup process, and quality tools.
  * Documented collaboration workflows, Git practices, contribution channels, review requirements, and upstream contribution standards.
  * Added guidance for local development, communication, session handoff, and deployment verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->