### PR TITLE
docs(contribute): 登记 Gitee 侧合并结果与双门槛经验(删分支时机/review+test API/跨平台 sha 分叉)

### DIFF
--- a/docs/contribute/UPSTREAM_COLLABORATION_STANDARD.md
+++ b/docs/contribute/UPSTREAM_COLLABORATION_STANDARD.md
@@ -92,10 +92,17 @@
 | 2026-09-05 | Issue | GitHub | #11 Windows 编译修复报告 + 收流方向询问 | https://github.com/xiaofang142/hivemtk/issues/11 | 开放 |
 | 2026-09-05 | PR | GitHub | #12 fix(user-server): Windows 编译修复(Closes #11) | https://github.com/xiaofang142/hivemtk/pull/12 | 待评审 |
 | 2026-09-05 | PR | GitHub | #13 docs(contribute): 贡献者文档三份 | https://github.com/xiaofang142/hivemtk/pull/13 | 待评审 |
-| 2026-09-05 | MR | Gitee | !1 fix(user-server): Windows 编译修复(首评承载 bug 报告+收流询问) | https://gitee.com/xhpmayun/hivemtk/pulls/1 | 待评审 |
-| 2026-09-05 | MR | Gitee | !2 docs(contribute): 贡献者文档三份 | https://gitee.com/xhpmayun/hivemtk/pulls/2 | 待评审 |
+| 2026-09-05 | MR | Gitee | !1 fix(user-server): Windows 编译修复(首评承载 bug 报告+收流询问) | https://gitee.com/xhpmayun/hivemtk/pulls/1 | ~~open~~ 已关闭(源分支清理触发,教训见下) |
+| 2026-09-05 | MR | Gitee | !2 docs(contribute): 贡献者文档三份 | https://gitee.com/xhpmayun/hivemtk/pulls/2 | ~~open~~ 已关闭(同上) |
+| 2026-09-05 | **PR 合并** | GitHub | **#12 / #13 已 squash 合入 master(61b0d3c / 7771ecb),#11 自动关闭** | https://github.com/xiaofang142/hivemtk/pull/12 | ✅ 已合并 |
+| 2026-09-05 | MR 重建 | Gitee | !3(=!1 内容)/ !4(=!2 内容),基于合并后 master 重建 | https://gitee.com/xhpmayun/hivemtk/pulls/3 · /pulls/4 | open,审查已过,卡"测试"标记 |
 
 > 2026-09-05 平台能力备注:Gitee 个人版 API 无法创建上游 Issue(`POST /repos/{owner}/issues` 报 "project or enterprise",该端点仅企业版可用)——**Gitee 侧 bug 报告以 MR 首条评论承载**(见 !1 评论);MR 创建/更新/评论 API 一切正常(jungle-hero token,最小权限 issues/pull_requests/projects)。Gitee MR 必须以 `head: fork用户:分支` 跨库形式创建。
+>
+> **⚠️ 流程教训(已固化)**:
+> 1. **删已合并分支必须等双平台 MR/PR 都合并后**,或删除前先检查 Gitee 侧是否还有 open MR——源分支删除会**自动关闭**依赖它的 Gitee MR(!1/!2 因此被关,重建为 !3/!4)。
+> 2. **Gitee 合并门槛链**:owner 审查(POST /pulls/{n}/review,204 即过)→ 测试标记("未通过设置的测试",**API 无法标记,必须网页端由测试员点头**)。GitHub 侧无此门槛。
+> 3. 双平台合并顺序定案:**先 GitHub PR 合并 → 同步 Gitee master → Gitee 侧若只有镜像同步需求则直接同步 master、不再重复发 MR**(避免双份历史)。
 
 ## 8. 合并后同步(上游→下游)
 


### PR DESCRIPTION
## 概述

同步 Gitee 侧已登记的流程教训到 UPSTREAM_COLLABORATION_STANDARD.md §7(Gitee 侧已合并:!3/!4/!6):

1. 删已合并分支前必须检查双平台 MR 状态(源分支删除会自动关闭 Gitee MR)
2. Gitee 合并门槛链:审查 POST /pulls/{n}/review → 测试 POST /pulls/{n}/test → 合并 PUT /pulls/{n}/merge(全程可 API 自动化)
3. 双平台 squash 产生独立 sha,跨平台分支必须以目标平台 master 为 base 重建

## 改动类型

- [x] 文档更新

## 关联

Gitee 同内容 MR: xhpmayun/hivemtk!6(已合并 a00e645)

已阅读并同意 CLA.md,贡献按 AGPL-3.0 分发。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the upstream collaboration status ledger with the latest merge and review states across GitHub and Gitee.
  - Documented platform-specific merge-gate requirements, including review and test-marker steps.
  - Added process guidance for coordinating merges, branch cleanup, and cross-platform synchronization to prevent dependent merge requests from closing unexpectedly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->